### PR TITLE
Change target-temp steps to whole numbers, and range 10-35

### DIFF
--- a/custom_components/airtouch2plus/Airtouch2PlusClimateEntity.py
+++ b/custom_components/airtouch2plus/Airtouch2PlusClimateEntity.py
@@ -17,6 +17,7 @@ from homeassistant.components.climate import (
     HVACMode,
     UnitOfTemperature,
     ATTR_TEMPERATURE,
+    PRECISION_TENTHS,
     PRECISION_WHOLE
 )
 from homeassistant.helpers.entity import DeviceInfo
@@ -36,7 +37,7 @@ class Airtouch2PlusClimateEntity(ClimateEntity):
     #
     _attr_max_temp = 35
     _attr_min_temp = 10
-    _attr_precision = PRECISION_WHOLE
+    _attr_precision = float = PRECISION_TENTHS
     _attr_target_temperature_step = PRECISION_WHOLE
     _attr_temperature_unit: str = UnitOfTemperature.CELSIUS
 

--- a/custom_components/airtouch2plus/Airtouch2PlusClimateEntity.py
+++ b/custom_components/airtouch2plus/Airtouch2PlusClimateEntity.py
@@ -17,7 +17,7 @@ from homeassistant.components.climate import (
     HVACMode,
     UnitOfTemperature,
     ATTR_TEMPERATURE,
-    PRECISION_TENTHS
+    PRECISION_WHOLE
 )
 from homeassistant.helpers.entity import DeviceInfo
 
@@ -34,8 +34,10 @@ class Airtouch2PlusClimateEntity(ClimateEntity):
     #
     # ClimateEntity attributes:
     #
-    _attr_precision: float = PRECISION_TENTHS
-    _attr_target_temperature_step: float = 0.1
+    _attr_max_temp = 35
+    _attr_min_temp = 10
+    _attr_precision = PRECISION_WHOLE
+    _attr_target_temperature_step = PRECISION_WHOLE
     _attr_temperature_unit: str = UnitOfTemperature.CELSIUS
 
     def __init__(self, at2plus_aircon: At2PlusAircon) -> None:


### PR DESCRIPTION
Update Set Temp Defaults in Airtouch2PlusClimateEntity.py

+ Change to whole degrees only. 22 is valid. 23 is valid. 22.1 or 22.5 is not.
+ Define supported Min/Max. Was inheriting default of 7-35. Airtouch2+ API doc confirms range is 10-35, confirmed on touchpad itself too.

Addresses Issue #20 